### PR TITLE
Improve api

### DIFF
--- a/picire/__init__.py
+++ b/picire/__init__.py
@@ -7,7 +7,7 @@
 
 from .abstract_dd import AbstractDD
 from .abstract_parallel_dd import AbstractParallelDD
-from .cli import __version__
+from .cli import __version__, call
 from .combined_iterator import CombinedIterator
 from .combined_parallel_dd import CombinedParallelDD
 from .light_dd import LightDD
@@ -15,16 +15,19 @@ from .parallel_dd import ParallelDD
 from .subprocess_test import ConcatTestBuilder, SubprocessTest
 
 
-__all__ = ['__version__',
-           'AbstractDD',
-           'AbstractParallelDD',
-           'cli',
-           'CombinedIterator',
-           'CombinedParallelDD',
-           'ConcatTestBuilder',
-           'config_iterators',
-           'config_splitters',
-           'global_structures',
-           'LightDD',
-           'ParallelDD',
-           'SubprocessTest']
+__all__ = [
+    '__version__',
+    'AbstractDD',
+    'AbstractParallelDD',
+    'call',
+    'cli',
+    'CombinedIterator',
+    'CombinedParallelDD',
+    'ConcatTestBuilder',
+    'config_iterators',
+    'config_splitters',
+    'global_structures',
+    'LightDD',
+    'ParallelDD',
+    'SubprocessTest'
+]

--- a/picire/cli.py
+++ b/picire/cli.py
@@ -102,7 +102,7 @@ def process_args(parser, args):
 
     args.tester_class = SubprocessTest
     args.tester_config = {
-        'enc': args.encoding,
+        'encoding': args.encoding,
         'command_pattern': '%s %%s' % abspath(args.test)
     }
 

--- a/picire/subprocess_test.py
+++ b/picire/subprocess_test.py
@@ -16,7 +16,7 @@ from .abstract_dd import AbstractDD
 
 class SubprocessTest(object):
 
-    def __init__(self, command_pattern, test_builder, test_pattern, enc):
+    def __init__(self, command_pattern, test_builder, test_pattern, encoding):
         """
         Wrapper around the script provided by the user. It decides about the
         interestingness based on the return code of executed script.
@@ -26,10 +26,10 @@ class SubprocessTest(object):
         :param test_builder: Callable object that creates test case from a configuration.
         :param test_pattern: The patter of the test's path. It contains one %s part
                              that will be replaced with the ID of the certain configurations.
-        :param enc: The encoding that will be used to save the tests.
+        :param encoding: The encoding that will be used to save the tests.
         """
         self.command_pattern = command_pattern
-        self.encoding = enc
+        self.encoding = encoding
         self.test_builder = test_builder
         self.test_pattern = test_pattern
 


### PR DESCRIPTION
* Add picire.call()
  Execute picire as if invoked from command line, however, control its
  behaviour not via command line arguments but function parameters.

* Change parameter of `SubprocessTest.__init__` from enc to encoding
  The more descriptive longer name is used throughout the package,
  aligning SubprocessTest as well.