### PR TITLE
Improve the handling of files

### DIFF
--- a/picire/subprocess_test.py
+++ b/picire/subprocess_test.py
@@ -47,8 +47,7 @@ class SubprocessTest(object):
         test_path = self.test_pattern % config_id
         test_dir = os.path.dirname(test_path)
 
-        if not os.path.exists(test_dir):
-            os.makedirs(test_dir)
+        os.makedirs(test_dir, exist_ok=True)
 
         with codecs.open(test_path, 'w', encoding=self.encoding, errors='ignore') as f:
             f.write(self.test_builder(config))


### PR DESCRIPTION
* Fix: use os.relpath() instead of os.realpath().
* Don't call os.abspath() multiple times on the same path.
* Make use of exist_ok keyword argument of os.makedirs().
* Use errors keyword argument of codecs.open() consistently.
* Use ConcatTestBuilder to generate the contents of the final
  minimal result file the same way as it is used durig minimization.