### PR TITLE
Rework how caches signal that they require a test builder

### DIFF
--- a/picire/cli.py
+++ b/picire/cli.py
@@ -7,7 +7,6 @@
 
 import chardet
 import codecs
-import inspect
 import logging
 import os
 import pkgutil
@@ -182,8 +181,9 @@ def call(*,
     logger.info('Initial test contains %d %ss', len(content), atom)
 
     test_builder = ConcatTestBuilder(content)
-    cache_config = {'test_builder': test_builder} if 'test_builder' in inspect.getfullargspec(cache_class)[0] else {}
-    cache = cache_class(**cache_config) if cache_class else None
+    cache = cache_class() if cache_class else None
+    if hasattr(cache, 'set_test_builder'):
+        cache.set_test_builder(test_builder)
 
     dd = reduce_class(tester_class(test_builder=test_builder,
                                    test_pattern=join(tests_dir, '%s', basename(input)),

--- a/picire/outcome_cache.py
+++ b/picire/outcome_cache.py
@@ -120,8 +120,11 @@ class ContentCache(OutcomeCache):
     Class that can cache the outcome of test cases by their content.
     """
 
-    def __init__(self, test_builder):
+    def __init__(self):
         self.container = dict()
+        self.test_builder = None
+
+    def set_test_builder(self, test_builder):
         self.test_builder = test_builder
 
     def add(self, config, result):


### PR DESCRIPTION
Instead of having a `test_builder` argument in the constructor,
test-builder-aware cache objects should have a
`set_test_builder(test_builder)` method.