### PR TITLE
Improve logging

### DIFF
--- a/picire/cli.py
+++ b/picire/cli.py
@@ -13,7 +13,6 @@ import os
 import pkgutil
 import time
 
-from functools import reduce
 from os.path import abspath, basename, exists, join, relpath
 from shutil import rmtree
 
@@ -169,10 +168,12 @@ def call(*,
     :return: The path to the minimal test case.
     """
 
-    # Get the parameters in a dictionary so that they can be pretty-printed later
+    # Get the parameters in a dictionary so that they can be pretty-printed
     # (minus src, as that parameter can be arbitrarily large)
     args = locals().copy()
     del args['src']
+    logger.info('Reduce session starts for %s\n%s',
+                input, ''.join(['\t%s: %s\n' % (k, v) for k, v in sorted(args.items())]))
 
     tests_dir = join(out, 'tests')
     os.makedirs(tests_dir, exist_ok=True)
@@ -182,9 +183,6 @@ def call(*,
         content = src.decode(encoding).splitlines(keepends=True)
     elif atom == 'char':
         content = src.decode(encoding)
-
-    logger.info('Reduce session starts for %s\n%s',
-                input, reduce(lambda x, y: x + y, ['\t%s: %s\n' % (k, v) for k, v in sorted(args.items())], ''))
     logger.info('Initial test contains %d %ss', len(content), atom)
 
     test_builder = ConcatTestBuilder(content)

--- a/picire/parallel_loop.py
+++ b/picire/parallel_loop.py
@@ -9,9 +9,7 @@ import logging
 import multiprocessing
 import os
 import psutil
-import traceback
 import signal
-import sys
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +52,7 @@ class Loop(object):
             if not target(*args):
                 self._break.value = 1
         except:
-            logger.warning(''.join(traceback.format_exception(*sys.exc_info())))
+            logger.warning('', exc_info=True)
             self._break.value = 1
 
         self._slots[i] = 0


### PR DESCRIPTION
Simplify exception logging in parallel loop
* Python's logging facility has support for adding exception trace to the log, there is no need to mimic/re-implement it.

Improve control of logging in CLI
* List all standard logging levels as choices for `--log-level`.
* Make complete disabling of logging possible.
* Add `-v` and `-q` command line option aliases for convenience.

Move parameter logging to the earliest possible position in picire.call