### PR TITLE
Minor improvements (consistent names, sensible defaults, value reuse)

### DIFF
--- a/picire/cli.py
+++ b/picire/cli.py
@@ -133,7 +133,8 @@ def process_args(parser, args):
 
         if args.combine_loops:
             args.reduce_class = CombinedParallelDD
-            args.reduce_config['config_iterator'] = CombinedIterator(args.subset_first, subset_iterator,
+            args.reduce_config['config_iterator'] = CombinedIterator(args.subset_first,
+                                                                     subset_iterator,
                                                                      complement_iterator)
         else:
             args.reduce_class = ParallelDD
@@ -148,7 +149,7 @@ def call(*,
          reduce_class, reduce_config,
          tester_class, tester_config,
          input, src, encoding, out,
-         atom,
+         atom='line',
          cache_class=None, cleanup=True):
     """
     Execute picire as if invoked from command line, however, control its
@@ -162,7 +163,7 @@ def call(*,
     :param src: Contents of the test case to reduce.
     :param encoding: Encoding of the input test case.
     :param out: Path to the output directory.
-    :param atom: Input granularity to work with during reduce ('char' or 'line').
+    :param atom: Input granularity to work with during reduce ('char' or 'line'; default: 'line').
     :param cache_class: Reference to the cache class to use.
     :param cleanup: Binary flag denoting whether removing auxiliary files at the end is enabled (default: True).
     :return: The path to the minimal test case.
@@ -202,7 +203,7 @@ def call(*,
 
     out_file = join(out, basename(input))
     with codecs.open(out_file, 'w', encoding=encoding, errors='ignore') as f:
-        f.write(ConcatTestBuilder(content)(min_set))
+        f.write(test_builder(min_set))
     logger.info('Result is saved to %s.', out_file)
 
     if cleanup:

--- a/picire/combined_iterator.py
+++ b/picire/combined_iterator.py
@@ -1,26 +1,28 @@
-# Copyright (c) 2016 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2017 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
+from . import config_iterators
+
 
 class CombinedIterator(object):
     """Callable iterator class that acts as generator when subset and complement check loops are combined."""
 
-    def __init__(self, subset_first, sub_it, compl_it):
+    def __init__(self, subset_first=True, subset_iterator=config_iterators.forward, complement_iterator=config_iterators.forward):
         """
         Initialize CombinedIterator with the basic settings describing the order of subset and complement checks
         together with the certain iterators.
 
         :param subset_first: Boolean value denoting whether the reduce has to start with the subset based approach or not.
-        :param sub_it: Reference to a generator function that provides config indices in an arbitrary order.
-        :param compl_it: Reference to a generator function that provides config indices in an arbitrary order.
+        :param subset_iterator: Reference to a generator function that provides config indices in an arbitrary order.
+        :param complement_iterator: Reference to a generator function that provides config indices in an arbitrary order.
         """
         self._subset_first = subset_first
-        self._subset_iterator = sub_it
-        self._complement_iterator = compl_it
+        self._subset_iterator = subset_iterator
+        self._complement_iterator = complement_iterator
 
     def __call__(self, n):
         """


### PR DESCRIPTION
* Rename arguments in CombinedIterator to follow the naming scheme
  used elsewhere in the code, and add sensible defaults.
* Add default for the atom argument of picire.call.
* Reuse existing test builder in picire.call.