### PR TITLE
Drop support of Python3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.pylintrc
+++ b/.pylintrc
@@ -19,7 +19,7 @@ disable=
     useless-object-inheritance, unnecessary-pass, duplicate-code,
     abstract-method, function-redefined, redefined-outer-name,
     import-outside-toplevel, inconsistent-return-statements,
-    consider-using-with, consider-using-f-string
+    consider-using-with
 
 [REPORTS]
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ test is **1-minimal**).
 Requirements
 ============
 
-* Python_ >= 3.5
+* Python_ >= 3.6
 
 .. _Python: https://www.python.org
 

--- a/picire/abstract_dd.py
+++ b/picire/abstract_dd.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -48,7 +48,7 @@ class AbstractDD(object):
         for run in itertools.count():
             logger.info('Run #%d', run)
             logger.info('\tConfig size: %d', len(config))
-            assert self._test_config(config, ('r%d' % run, 'assert')) is Outcome.FAIL
+            assert self._test_config(config, (f'r{run}', 'assert')) is Outcome.FAIL
 
             # Minimization ends if the configuration is already reduced to a single unit.
             if len(config) < 2:

--- a/picire/cli.py
+++ b/picire/cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -42,7 +42,7 @@ def create_parser():
             return float('inf')
         value = int(value)
         if value < 2:
-            raise argparse.ArgumentTypeError('invalid value: {value!r} (must be at least 2)'.format(value=value))
+            raise argparse.ArgumentTypeError(f'invalid value: {value!r} (must be at least 2)')
         return value
 
     parser = argparse.ArgumentParser(description='Command line interface of the "picire" test case reducer')
@@ -97,7 +97,7 @@ def process_args(args):
 
     args.input = realpath(args.input)
     if not exists(args.input):
-        raise ValueError('Test case does not exist: %s' % args.input)
+        raise ValueError(f'Test case does not exist: {args.input}')
 
     with open(args.input, 'rb') as f:
         args.src = f.read()
@@ -106,17 +106,17 @@ def process_args(args):
         try:
             codecs.lookup(args.encoding)
         except LookupError as e:
-            raise ValueError('The given encoding (%s) is not known.' % args.encoding) from e
+            raise ValueError(f'The given encoding ({args.encoding}) is not known.') from e
     else:
         args.encoding = chardet.detect(args.src)['encoding'] or 'latin-1'
 
     args.src = args.src.decode(args.encoding)
 
-    args.out = realpath(args.out if args.out else '%s.%s' % (args.input, time.strftime('%Y%m%d_%H%M%S')))
+    args.out = realpath(args.out if args.out else f'{args.input}.{time.strftime("%Y%m%d_%H%M%S")}')
 
     args.test = realpath(args.test)
     if not exists(args.test) or not os.access(args.test, os.X_OK):
-        raise ValueError('Tester program does not exist or isn\'t executable: %s' % args.test)
+        raise ValueError(f'Tester program does not exist or isn\'t executable: {args.test}')
 
     args.tester_class = SubprocessTest
     args.tester_config = dict(command_pattern=[args.test, '%s'],
@@ -165,11 +165,11 @@ def log_args(title, args):
                 k_log = _log_args(k)
                 v_log = _log_args(v)
                 if isinstance(v_log, list):
-                    log += ['%s:' % k_log]
+                    log += [f'{k_log}:']
                     for line in v_log:
-                        log += ['\t' + line]
+                        log += [f'\t{line}']
                 else:
-                    log += ['%s: %s' % (k_log, v_log)]
+                    log += [f'{k_log}: {v_log}']
             return log if len(log) > 1 else log[0]
         if isinstance(args, list):
             v_logs = [_log_args(v) for v in args]
@@ -179,7 +179,7 @@ def log_args(title, args):
                     if not isinstance(v_log, list):
                         v_log = [v_log]
                     for i, line in enumerate(v_log):
-                        log += ['%s %s' % ('-' if i == 0 else ' ', line)]
+                        log += [f'{"-" if i == 0 else " "} {line}']
             else:
                 log = ', '.join(v_log for v_log in v_logs)
             return log
@@ -233,7 +233,7 @@ def reduce(src, *,
 
         dd = reduce_class(tester_class(test_builder=test_builder, **tester_config),
                           cache=cache,
-                          id_prefix=('a%d' % atom_cnt,),
+                          id_prefix=(f'a{atom_cnt}',),
                           **reduce_config)
         min_set = dd(list(range(len(src))))
         src = test_builder(min_set)

--- a/picire/combined_parallel_dd.py
+++ b/picire/combined_parallel_dd.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -56,11 +56,11 @@ class CombinedParallelDD(AbstractParallelDD):
                 continue
 
             if i < n:
-                config_id = ('r%d' % run, 's%d' % i)
+                config_id = (f'r{run}', f's{i}')
                 config_set = subsets[i]
             else:
                 i = int((i - n + complement_offset) % n) + n
-                config_id = ('r%d' % run, 'c%d' % (i - n))
+                config_id = (f'r{run}', f'c{i - n}')
                 config_set = [c for si, s in enumerate(subsets) for c in s if si != i - n]
 
             # If we checked this test before, return its result

--- a/picire/config_splitters.py
+++ b/picire/config_splitters.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -42,7 +42,7 @@ class ZellerSplit(object):
 
     def __str__(self):
         cls = self.__class__
-        return '%s.%s(n=%s)' % (cls.__module__, cls.__name__, self._n)
+        return f'{cls.__module__}.{cls.__name__}(n={self._n})'
 
 
 class BalancedSplit(object):
@@ -74,7 +74,7 @@ class BalancedSplit(object):
 
     def __str__(self):
         cls = self.__class__
-        return '%s.%s(n=%s)' % (cls.__module__, cls.__name__, self._n)
+        return f'{cls.__module__}.{cls.__name__}(n={self._n})'
 
 
 # Aliases for split classes to help their identification in CLI.

--- a/picire/dd.py
+++ b/picire/dd.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -80,7 +80,7 @@ class DD(AbstractDD):
             if i is None:
                 continue
 
-            config_id = ('r%d' % run, 's%d' % i)
+            config_id = (f'r{run}', f's{i}')
             subset = subsets[i]
 
             # Get the outcome either from cache or by testing it.
@@ -108,7 +108,7 @@ class DD(AbstractDD):
                 continue
             i = int((i + complement_offset) % n)
 
-            config_id = ('r%d' % run, 'c%d' % i)
+            config_id = (f'r{run}', f'c{i}')
             complement = [c for si, s in enumerate(subsets) for c in s if si != i]
 
             outcome = self._lookup_cache(complement, config_id) or self._test_config(complement, config_id)

--- a/picire/outcome.py
+++ b/picire/outcome.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -14,4 +14,4 @@ class Outcome(Enum):
     FAIL = 'FAIL'
 
     def __repr__(self):
-        return '<%s.%s>' % (self.__class__.__name__, self.name)
+        return f'<{self.__class__.__name__}.{self.name}>'

--- a/picire/outcome_cache.py
+++ b/picire/outcome_cache.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -99,7 +99,7 @@ class ConfigCache(OutcomeCache):
     def __str__(self):
         def _str(p):
             if p.result is not None:
-                s.append('\t[%s]: %r,\n' % (', '.join(repr(cs) for cs in config), p.result.name))
+                s.append(f'\t[{", ".join(repr(cs) for cs in config)}]: {p.result.name!r},\n')
             for cs, e in sorted(p.tail.items()):
                 config.append(cs)
                 _str(e)
@@ -131,7 +131,7 @@ class ContentCache(OutcomeCache):
         return self.container.get(self.test_builder(config), None)
 
     def __str__(self):
-        return '{\n%s}' % ''.join('\t%r: %r,\n' % (k, v.name) for k, v in sorted(self.container.items()))
+        return '{\n%s}' % ''.join(f'\t{k!r}: {v.name!r},\n' for k, v in sorted(self.container.items()))
 
 
 # Aliases for cache classes to help their identification in CLI.

--- a/picire/parallel_dd.py
+++ b/picire/parallel_dd.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -83,7 +83,7 @@ class ParallelDD(AbstractParallelDD):
             if i is None:
                 continue
 
-            config_id = ('r%d' % run, 's%d' % i)
+            config_id = (f'r{run}', f's{i}')
             subset = subsets[i]
 
             # If we had this test before, return the saved result.
@@ -125,7 +125,7 @@ class ParallelDD(AbstractParallelDD):
                 continue
             i = int((i + complement_offset) % n)
 
-            config_id = ('r%d' % run, 'c%d' % i)
+            config_id = (f'r{run}', f'c{i}')
             complement = [c for si, s in enumerate(subsets) for c in s if si != i]
 
             # If we had this test before, return its result

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,17 +14,18 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Testing
 platform = any
 
 [options]
 packages = find:
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     chardet
     importlib-metadata; python_version < "3.8"

--- a/tests/resources/exp-sumprod10-prod.py
+++ b/tests/resources/exp-sumprod10-prod.py
@@ -1,4 +1,4 @@
 prod = 1
 for i in range(1,11):
     prod *= i
-print('prod: %d' % prod)
+print(f'prod: {prod}')

--- a/tests/resources/exp-sumprod10-sum.py
+++ b/tests/resources/exp-sumprod10-sum.py
@@ -1,4 +1,4 @@
 sum = 0
 for i in range(1,11):
     sum += i
-print('sum: %d' % sum)
+print(f'sum: {sum}')

--- a/tests/resources/inp-sumprod10.py
+++ b/tests/resources/inp-sumprod10.py
@@ -6,5 +6,5 @@ for i in range(1,11):
     sum += i
     prod *= i
 
-print('sum: %d' % sum)
-print('prod: %d' % prod)
+print(f'sum: {sum}')
+print(f'prod: {prod}')

--- a/tests/resources/sut-json-load.py
+++ b/tests/resources/sut-json-load.py
@@ -7,4 +7,4 @@ import sys
 with open(sys.argv[1], 'r') as f:
     j = json.load(f)
 
-print("%s" % repr(j))
+print(f'j!r')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -36,7 +36,7 @@ class TestCli:
     def _run_picire(self, test, inp, exp, tmpdir, args):
         out_dir = str(tmpdir)
         cmd = (sys.executable, '-m', 'picire') \
-              + ('--test=' + test + script_ext, '--input=' + inp, '--out=' + out_dir) \
+              + (f'--test={test}{script_ext}', f'--input={inp}', f'--out={out_dir}') \
               + ('--log-level=TRACE', ) \
               + args
         subprocess.run(cmd, cwd=resources_dir, check=True)


### PR DESCRIPTION
Python3.5 has reached the end of its lifetime two years ago, hence Picire also stops supporting it. The patch introduces the usage of f-strings - supported from Python3.6 - and unifies string representations to use it where possible.
It also enables the 'consider-using-f-string' pylint checker.