### PR TITLE
Use decorator-based registry pattern for iterators, splitters, and caches

### DIFF
--- a/picire/__init__.py
+++ b/picire/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -13,9 +13,11 @@ from .abstract_parallel_dd import AbstractParallelDD
 from .cli import __version__, reduce
 from .combined_iterator import CombinedIterator
 from .combined_parallel_dd import CombinedParallelDD
+from .config_iterators import IteratorRegistry
+from .config_splitters import SplitterRegistry
 from .dd import DD
 from .outcome import Outcome
-from .outcome_cache import ConfigCache, ContentCache, OutcomeCache
+from .outcome_cache import CacheRegistry, ConfigCache, ContentCache, OutcomeCache
 from .parallel_dd import ParallelDD
 from .shared_cache import shared_cache_decorator
 from .subprocess_test import ConcatTestBuilder, SubprocessTest

--- a/picire/config_iterators.py
+++ b/picire/config_iterators.py
@@ -1,13 +1,25 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-forward = range  #: Generator returning numbers from 0 to n-1.
+class IteratorRegistry(object):
+    registry = {}
+
+    @classmethod
+    def register(cls, iter_name):
+        def decorator(iter_fn):
+            cls.registry[iter_name] = iter_fn
+            return iter_fn
+        return decorator
 
 
+forward = IteratorRegistry.register('forward')(range)  #: Generator returning numbers from 0 to n-1.
+
+
+@IteratorRegistry.register('backward')
 def backward(n):
     """
     Generator returning numbers from n - 1 to 0 decreasing by 1.
@@ -18,6 +30,7 @@ def backward(n):
     yield from range(n - 1, -1, -1)
 
 
+@IteratorRegistry.register('skip')
 def skip(n):
     """
     Do not return anything. Used to skip subset (or, less often, complement)
@@ -30,6 +43,7 @@ def skip(n):
     yield from ()
 
 
+@IteratorRegistry.register('random')
 def random(n):
     """
     Returns numbers 0..n-1 in random order.

--- a/picire/config_splitters.py
+++ b/picire/config_splitters.py
@@ -1,11 +1,22 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
+class SplitterRegistry(object):
+    registry = {}
 
+    @classmethod
+    def register(cls, split_name):
+        def decorator(split_class):
+            cls.registry[split_name] = split_class
+            return split_class
+        return decorator
+
+
+@SplitterRegistry.register('zeller')
 class ZellerSplit(object):
     """
     Splits up the input config into n pieces as used by Zeller in the original
@@ -45,6 +56,7 @@ class ZellerSplit(object):
         return f'{cls.__module__}.{cls.__name__}(n={self._n})'
 
 
+@SplitterRegistry.register('balanced')
 class BalancedSplit(object):
     """
     Slightly different version of Zeller's split. This version keeps the split
@@ -75,8 +87,3 @@ class BalancedSplit(object):
     def __str__(self):
         cls = self.__class__
         return f'{cls.__module__}.{cls.__name__}(n={self._n})'
-
-
-# Aliases for split classes to help their identification in CLI.
-zeller = ZellerSplit
-balanced = BalancedSplit

--- a/picire/outcome_cache.py
+++ b/picire/outcome_cache.py
@@ -1,11 +1,22 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
+class CacheRegistry(object):
+    registry = {}
 
+    @classmethod
+    def register(cls, cache_name):
+        def decorator(cache_class):
+            cls.registry[cache_name] = cache_class
+            return cache_class
+        return decorator
+
+
+@CacheRegistry.register('none')
 class OutcomeCache(object):
     """
     Base class for configuration outcome caching strategies. It does not
@@ -51,6 +62,7 @@ class OutcomeCache(object):
         return '{}'
 
 
+@CacheRegistry.register('config')
 class ConfigCache(OutcomeCache):
 
     class _Entry(object):
@@ -112,6 +124,7 @@ class ConfigCache(OutcomeCache):
         return ''.join(s)
 
 
+@CacheRegistry.register('content')
 class ContentCache(OutcomeCache):
     """
     Class that can cache the outcome of test cases by their content.
@@ -132,9 +145,3 @@ class ContentCache(OutcomeCache):
 
     def __str__(self):
         return '{\n%s}' % ''.join(f'\t{k!r}: {v.name!r},\n' for k, v in sorted(self.container.items()))
-
-
-# Aliases for cache classes to help their identification in CLI.
-none = OutcomeCache
-config = ConfigCache
-content = ContentCache

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -92,32 +92,32 @@ class TestApi:
         assert output == expect
 
     @pytest.mark.parametrize('split, subset_first, subset_iterator, complement_iterator, cache', [
-        (picire.config_splitters.balanced, True, picire.config_iterators.forward, picire.config_iterators.forward, picire.OutcomeCache),
-        (picire.config_splitters.zeller, True, picire.config_iterators.forward, picire.config_iterators.backward, picire.ConfigCache),
-        (picire.config_splitters.balanced, False, picire.config_iterators.backward, picire.config_iterators.forward, picire.OutcomeCache),
-        (picire.config_splitters.zeller, False, picire.config_iterators.backward, picire.config_iterators.backward, picire.ConfigCache),
-        (picire.config_splitters.balanced, True, picire.config_iterators.skip, picire.config_iterators.forward, picire.OutcomeCache),
-        (picire.config_splitters.zeller, True, picire.config_iterators.skip, picire.config_iterators.backward, picire.ConfigCache),
+        (picire.config_splitters.BalancedSplit, True, picire.config_iterators.forward, picire.config_iterators.forward, picire.OutcomeCache),
+        (picire.config_splitters.ZellerSplit, True, picire.config_iterators.forward, picire.config_iterators.backward, picire.ConfigCache),
+        (picire.config_splitters.BalancedSplit, False, picire.config_iterators.backward, picire.config_iterators.forward, picire.OutcomeCache),
+        (picire.config_splitters.ZellerSplit, False, picire.config_iterators.backward, picire.config_iterators.backward, picire.ConfigCache),
+        (picire.config_splitters.BalancedSplit, True, picire.config_iterators.skip, picire.config_iterators.forward, picire.OutcomeCache),
+        (picire.config_splitters.ZellerSplit, True, picire.config_iterators.skip, picire.config_iterators.backward, picire.ConfigCache),
     ])
     def test_dd(self, interesting, config, expect, granularity, split, subset_first, subset_iterator, complement_iterator, cache):
         self._run_picire(interesting, config, expect, granularity, picire.DD, split, subset_first, subset_iterator, complement_iterator, cache)
 
     @pytest.mark.parametrize('split, subset_first, subset_iterator, complement_iterator, cache', [
-        (picire.config_splitters.zeller, False, picire.config_iterators.forward, picire.config_iterators.forward, picire.ConfigCache),
-        (picire.config_splitters.balanced, False, picire.config_iterators.forward, picire.config_iterators.backward, picire.OutcomeCache),
-        (picire.config_splitters.zeller, True, picire.config_iterators.backward, picire.config_iterators.forward, picire.ConfigCache),
-        (picire.config_splitters.balanced, True, picire.config_iterators.backward, picire.config_iterators.backward, picire.OutcomeCache),
-        (picire.config_splitters.zeller, True, picire.config_iterators.skip, picire.config_iterators.forward, picire.ConfigCache),
-        (picire.config_splitters.balanced, True, picire.config_iterators.skip, picire.config_iterators.backward, picire.OutcomeCache),
+        (picire.config_splitters.ZellerSplit, False, picire.config_iterators.forward, picire.config_iterators.forward, picire.ConfigCache),
+        (picire.config_splitters.BalancedSplit, False, picire.config_iterators.forward, picire.config_iterators.backward, picire.OutcomeCache),
+        (picire.config_splitters.ZellerSplit, True, picire.config_iterators.backward, picire.config_iterators.forward, picire.ConfigCache),
+        (picire.config_splitters.BalancedSplit, True, picire.config_iterators.backward, picire.config_iterators.backward, picire.OutcomeCache),
+        (picire.config_splitters.ZellerSplit, True, picire.config_iterators.skip, picire.config_iterators.forward, picire.ConfigCache),
+        (picire.config_splitters.BalancedSplit, True, picire.config_iterators.skip, picire.config_iterators.backward, picire.OutcomeCache),
     ])
     def test_parallel(self, interesting, config, expect, granularity, split, subset_first, subset_iterator, complement_iterator, cache):
         self._run_picire(interesting, config, expect, granularity, picire.ParallelDD, split, subset_first, subset_iterator, complement_iterator, cache)
 
     @pytest.mark.parametrize('split, subset_first, subset_iterator, complement_iterator, cache', [
-        (picire.config_splitters.zeller, True, picire.config_iterators.forward, picire.config_iterators.forward, picire.OutcomeCache),
-        (picire.config_splitters.balanced, True, picire.config_iterators.forward, picire.config_iterators.backward, picire.ConfigCache),
-        (picire.config_splitters.zeller, False, picire.config_iterators.backward, picire.config_iterators.forward, picire.OutcomeCache),
-        (picire.config_splitters.balanced, False, picire.config_iterators.backward, picire.config_iterators.backward, picire.ConfigCache),
+        (picire.config_splitters.ZellerSplit, True, picire.config_iterators.forward, picire.config_iterators.forward, picire.OutcomeCache),
+        (picire.config_splitters.BalancedSplit, True, picire.config_iterators.forward, picire.config_iterators.backward, picire.ConfigCache),
+        (picire.config_splitters.ZellerSplit, False, picire.config_iterators.backward, picire.config_iterators.forward, picire.OutcomeCache),
+        (picire.config_splitters.BalancedSplit, False, picire.config_iterators.backward, picire.config_iterators.backward, picire.ConfigCache),
     ])
     def test_combined(self, interesting, config, expect, granularity, split, subset_first, subset_iterator, complement_iterator, cache):
         self._run_picire(interesting, config, expect, granularity, picire.CombinedParallelDD, split, subset_first, subset_iterator, complement_iterator, cache)


### PR DESCRIPTION
This refactoring has two benefits:
- CLI does not need to look into specific modules to discover iterators, splitters, and caches with a specific name pattern.
- Iterator, splitter, or cache names do not need to follow Python identifier rules (e.g., they can contain dashes).