### PR TITLE
Use `math.inf` instead of `float('inf')`

### DIFF
--- a/picire/cli.py
+++ b/picire/cli.py
@@ -10,6 +10,7 @@ import codecs
 import os
 import time
 
+from math import inf
 from multiprocessing import cpu_count
 from os.path import basename, exists, join, realpath
 from shutil import rmtree
@@ -40,7 +41,7 @@ __version__ = metadata.version(__package__)
 def create_parser():
     def int_or_inf(value):
         if value == 'inf':
-            return float('inf')
+            return inf
         value = int(value)
         if value < 2:
             raise argparse.ArgumentTypeError(f'invalid value: {value!r} (must be at least 2)')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@
 # according to those terms.
 
 import logging
+import math
 import pytest
 
 import picire
@@ -61,7 +62,7 @@ class CaseTest:
 ])
 @pytest.mark.parametrize('granularity', [
     2,
-    float('inf'),
+    math.inf,
 ])
 class TestApi:
 


### PR DESCRIPTION
The constant has been available since py3.5.