### PR TITLE
Cache optimizations

### DIFF
--- a/picire/abstract_dd.py
+++ b/picire/abstract_dd.py
@@ -9,7 +9,7 @@
 import itertools
 import logging
 
-from .cache import OutcomeCache
+from .cache import NoCache
 from .outcome import Outcome
 from .splitter import ZellerSplit
 
@@ -34,7 +34,7 @@ class AbstractDD(object):
         """
         self._test = test
         self._split = split or ZellerSplit()
-        self._cache = cache or OutcomeCache()
+        self._cache = cache or NoCache()
         self._id_prefix = id_prefix or ()
         self._iteration_prefix = ()
         self._dd_star = dd_star

--- a/picire/cache.py
+++ b/picire/cache.py
@@ -1,9 +1,15 @@
 # Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2023 Daniel Vince.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
+
+from hashlib import sha3_256
+
+from .outcome import Outcome
+
 
 class CacheRegistry(object):
     registry = {}
@@ -16,12 +22,9 @@ class CacheRegistry(object):
         return decorator
 
 
-@CacheRegistry.register('none')
 class OutcomeCache(object):
     """
-    Base class for configuration outcome caching strategies. It does not
-    implement a caching strategy itself (or, it implements the disable-cache
-    strategy) but leaves the implementation of real strategies to subclasses.
+    Abstract base class for configuration outcome caching strategies.
     """
 
     def set_test_builder(self, test_builder):
@@ -32,7 +35,7 @@ class OutcomeCache(object):
             configuration. It must be identical to the test builder used by the
             tester class.
         """
-        pass
+        raise NotImplementedError()
 
     def add(self, config, result):
         """
@@ -41,7 +44,7 @@ class OutcomeCache(object):
         :param config: The configuration to save.
         :param result: The outcome of the added configuration.
         """
-        pass
+        raise NotImplementedError()
 
     def lookup(self, config):
         """
@@ -50,12 +53,40 @@ class OutcomeCache(object):
         :param config: The configuration we are looking for.
         :return: PASS or FAIL if config is in the cache; None, otherwise.
         """
-        return None
+        raise NotImplementedError()
 
     def clear(self):
         """
         Clear the cache.
         """
+        raise NotImplementedError()
+
+
+@CacheRegistry.register('none')
+class NoCache(OutcomeCache):
+    """
+    Implementation of a disabled cache. Does not store anything, so no cache hit
+    can occur, ever.
+    """
+
+    def __init__(self, *, cache_fail=False, evict_after_fail=True):
+        """
+        :param cache_fail: Unused, only added for compatibility with other cache
+            implementations.
+        :param evict_after_fail: Unused, only added for compatibility with other
+            cache implementations.
+        """
+
+    def set_test_builder(self, test_builder):
+        pass
+
+    def add(self, config, result):
+        pass
+
+    def lookup(self, config):
+        return None
+
+    def clear(self):
         pass
 
     def __str__(self):
@@ -64,6 +95,11 @@ class OutcomeCache(object):
 
 @CacheRegistry.register('config')
 class ConfigCache(OutcomeCache):
+    """
+    Re-implementation of Zeller's original caching approach. The cache
+    associates configurations (i.e., lists of elements) with their test
+    outcomes, using a tree as the underlying data structure.
+    """
 
     class _Entry(object):
         """
@@ -86,16 +122,40 @@ class ConfigCache(OutcomeCache):
             self.result = None  # Result so far
             self.tail = {}  # Points to outcome of tail
 
-    def __init__(self):
+    def __init__(self, *, cache_fail=False, evict_after_fail=True):
+        """
+        :param cache_fail: Add configurations with FAIL outcome to the cache.
+        :param evict_after_fail: When a configuration with a FAIL outcome is
+            added to the cache, evict all larger configurations.
+        """
+        # NOTE: evict_after_fail=True should be safe as after a fail is found,
+        # reduction continues from there, generating only even smaller test
+        # cases, and larger tests are never re-tested again.
+        self._cache_fail = cache_fail
+        self._evict_after_fail = evict_after_fail
         self._root = self._Entry()
 
+    def set_test_builder(self, test_builder):
+        pass
+
+    def _evict(self, p, length):
+        if length == 0:
+            p.tail = {}
+        else:
+            for e in p.tail.values():
+                self._evict(e, length - 1)
+
     def add(self, config, result):
-        p = self._root
-        for cs in config:
-            if cs not in p.tail:
-                p.tail[cs] = self._Entry()
-            p = p.tail[cs]
-        p.result = result
+        if result is Outcome.PASS or self._cache_fail:
+            p = self._root
+            for cs in config:
+                if cs not in p.tail:
+                    p.tail[cs] = self._Entry()
+                p = p.tail[cs]
+            p.result = result
+
+        if result is Outcome.FAIL and self._evict_after_fail:
+            self._evict(self._root, len(config))
 
     def lookup(self, config):
         p = self._root
@@ -127,21 +187,105 @@ class ConfigCache(OutcomeCache):
 @CacheRegistry.register('content')
 class ContentCache(OutcomeCache):
     """
-    Class that can cache the outcome of test cases by their content.
+    A cache implementation that associates test contents (built from
+    configurations) with their test outcomes.
     """
 
-    def __init__(self):
-        self.container = {}
-        self.test_builder = None
+    def __init__(self, *, cache_fail=False, evict_after_fail=True):
+        """
+        :param cache_fail: Add configurations with FAIL outcome to the cache.
+        :param evict_after_fail: When a configuration with a FAIL outcome is
+            added to the cache, evict all larger configurations.
+        """
+        # NOTE: evict_after_fail=True should be safe as after a fail is found,
+        # reduction continues from there, generating only even smaller test
+        # cases, and larger tests are never re-tested again.
+        self._cache_fail = cache_fail
+        self._evict_after_fail = evict_after_fail
+        self._container = {}
+        self._test_builder = None
 
     def set_test_builder(self, test_builder):
-        self.test_builder = test_builder
+        self._test_builder = test_builder
 
     def add(self, config, result):
-        self.container[self.test_builder(config)] = result
+        if result is Outcome.FAIL and not self._cache_fail and not self._evict_after_fail:
+            return
+
+        test_content = self._test_builder(config)
+
+        if result is Outcome.PASS or self._cache_fail:
+            self._container[test_content] = result
+
+        if result is Outcome.FAIL and self._evict_after_fail:
+            length = len(test_content)
+            evicted = [c for c in self._container if len(c) > length]
+            for c in evicted:
+                del self._container[c]
 
     def lookup(self, config):
-        return self.container.get(self.test_builder(config), None)
+        return self._container.get(self._test_builder(config), None)
+
+    def clear(self):
+        pass
 
     def __str__(self):
-        return '{\n%s}' % ''.join(f'\t{k!r}: {v.name!r},\n' for k, v in sorted(self.container.items()))
+        return '{\n%s}' % ''.join(f'\t{c!r}: {r.name!r},\n' for c, r in sorted(self._container.items()))
+
+
+@CacheRegistry.register('content-hash')
+class ContentHashCache(OutcomeCache):
+    """
+    A cache implementation that associates hashed test contents (built from
+    configurations and hashed afterwards) with their test outcomes.
+    """
+
+    def __init__(self, *, cache_fail=False, evict_after_fail=True, hash_ctor=sha3_256):
+        """
+        :param cache_fail: Unused, only added for compatibility with other cache
+            implementations.
+        :param evict_after_fail: When a configuration with a FAIL outcome is
+            added to the cache, evict all larger configurations.
+        :param hash_ctor: A hash object constructor from hashlib.
+        """
+        # NOTE: Caching by hashed content is only safe if FAIL outcomes are not
+        # stored in the cache. Therefore, the value of the cache_fail argument
+        # is not taken into account but is forced to False.
+        # NOTE: evict_after_fail=True should be safe as after a fail is found,
+        # reduction continues from there, generating only even smaller test
+        # cases, and larger tests are never re-tested again.
+        self._evict_after_fail = evict_after_fail
+        self._hash_ctor = hash_ctor
+        self._container = {}
+        self._test_builder = None
+
+    def _hash_content(self, test_content):
+        return self._hash_ctor(test_content.encode('utf-8')).digest()
+
+    def set_test_builder(self, test_builder):
+        self._test_builder = test_builder
+
+    def add(self, config, result):
+        if result is Outcome.FAIL and not self._evict_after_fail:
+            return
+
+        test_content = self._test_builder(config)
+        length = len(test_content)
+
+        if result is Outcome.PASS:
+            self._container[self._hash_content(test_content)] = (result, length)
+
+        if result is Outcome.FAIL and self._evict_after_fail:
+            evicted = [h for h, (_, l) in self._container.items() if l > length]
+            for h in evicted:
+                del self._container[h]
+
+    def lookup(self, config):
+        result, _ = self._container.get(self._hash_content(self._test_builder(config)), (None, None))
+        return result
+
+    def clear(self):
+        pass
+
+    def __str__(self):
+        return '{\n%s}' % ''.join(f'\t{h.hex()}/{l}: {r.name!r},\n' for h, (r, l) in sorted(self._container.items()))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2023 Daniel Vince.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -93,11 +94,11 @@ class TestApi:
         assert output == expect
 
     @pytest.mark.parametrize('split, subset_first, subset_iterator, complement_iterator, cache', [
-        (picire.splitter.BalancedSplit, True, picire.iterator.forward, picire.iterator.forward, picire.cache.OutcomeCache),
+        (picire.splitter.BalancedSplit, True, picire.iterator.forward, picire.iterator.forward, picire.cache.NoCache),
         (picire.splitter.ZellerSplit, True, picire.iterator.forward, picire.iterator.backward, picire.cache.ConfigCache),
-        (picire.splitter.BalancedSplit, False, picire.iterator.backward, picire.iterator.forward, picire.cache.OutcomeCache),
+        (picire.splitter.BalancedSplit, False, picire.iterator.backward, picire.iterator.forward, picire.cache.NoCache),
         (picire.splitter.ZellerSplit, False, picire.iterator.backward, picire.iterator.backward, picire.cache.ConfigCache),
-        (picire.splitter.BalancedSplit, True, picire.iterator.skip, picire.iterator.forward, picire.cache.OutcomeCache),
+        (picire.splitter.BalancedSplit, True, picire.iterator.skip, picire.iterator.forward, picire.cache.NoCache),
         (picire.splitter.ZellerSplit, True, picire.iterator.skip, picire.iterator.backward, picire.cache.ConfigCache),
     ])
     def test_dd(self, interesting, config, expect, granularity, split, subset_first, subset_iterator, complement_iterator, cache):
@@ -105,19 +106,19 @@ class TestApi:
 
     @pytest.mark.parametrize('split, subset_first, subset_iterator, complement_iterator, cache', [
         (picire.splitter.ZellerSplit, False, picire.iterator.forward, picire.iterator.forward, picire.cache.ConfigCache),
-        (picire.splitter.BalancedSplit, False, picire.iterator.forward, picire.iterator.backward, picire.cache.OutcomeCache),
+        (picire.splitter.BalancedSplit, False, picire.iterator.forward, picire.iterator.backward, picire.cache.NoCache),
         (picire.splitter.ZellerSplit, True, picire.iterator.backward, picire.iterator.forward, picire.cache.ConfigCache),
-        (picire.splitter.BalancedSplit, True, picire.iterator.backward, picire.iterator.backward, picire.cache.OutcomeCache),
+        (picire.splitter.BalancedSplit, True, picire.iterator.backward, picire.iterator.backward, picire.cache.NoCache),
         (picire.splitter.ZellerSplit, True, picire.iterator.skip, picire.iterator.forward, picire.cache.ConfigCache),
-        (picire.splitter.BalancedSplit, True, picire.iterator.skip, picire.iterator.backward, picire.cache.OutcomeCache),
+        (picire.splitter.BalancedSplit, True, picire.iterator.skip, picire.iterator.backward, picire.cache.NoCache),
     ])
     def test_parallel(self, interesting, config, expect, granularity, split, subset_first, subset_iterator, complement_iterator, cache):
         self._run_picire(interesting, config, expect, granularity, picire.ParallelDD, split, subset_first, subset_iterator, complement_iterator, cache)
 
     @pytest.mark.parametrize('split, subset_first, subset_iterator, complement_iterator, cache', [
-        (picire.splitter.ZellerSplit, True, picire.iterator.forward, picire.iterator.forward, picire.cache.OutcomeCache),
+        (picire.splitter.ZellerSplit, True, picire.iterator.forward, picire.iterator.forward, picire.cache.NoCache),
         (picire.splitter.BalancedSplit, True, picire.iterator.forward, picire.iterator.backward, picire.cache.ConfigCache),
-        (picire.splitter.ZellerSplit, False, picire.iterator.backward, picire.iterator.forward, picire.cache.OutcomeCache),
+        (picire.splitter.ZellerSplit, False, picire.iterator.backward, picire.iterator.forward, picire.cache.NoCache),
         (picire.splitter.BalancedSplit, False, picire.iterator.backward, picire.iterator.backward, picire.cache.ConfigCache),
     ])
     def test_combined(self, interesting, config, expect, granularity, split, subset_first, subset_iterator, complement_iterator, cache):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2023 Daniel Vince.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -48,12 +49,12 @@ class TestCli:
         assert outb == expb
 
     @pytest.mark.parametrize('args', [
-        ('--split=balanced', '--subset-iterator=forward', '--complement-iterator=forward', '--cache=none'),
-        ('--split=zeller', '--subset-iterator=forward', '--complement-iterator=backward', '--cache=config'),
-        ('--split=balanced', '--complement-first', '--subset-iterator=backward', '--complement-iterator=forward', '--cache=content'),
-        ('--split=zeller', '--complement-first', '--subset-iterator=backward', '--complement-iterator=backward', '--cache=none'),
-        ('--split=balanced', '--subset-iterator=skip', '--complement-iterator=forward', '--cache=config'),
-        ('--split=zeller', '--subset-iterator=skip', '--complement-iterator=backward', '--cache=content'),
+        ('--split=balanced', '--subset-iterator=forward', '--complement-iterator=forward', '--cache=config'),
+        ('--split=zeller', '--subset-iterator=forward', '--complement-iterator=backward', '--cache=content'),
+        ('--split=balanced', '--complement-first', '--subset-iterator=backward', '--complement-iterator=forward', '--cache=content-hash'),
+        ('--split=zeller', '--complement-first', '--subset-iterator=backward', '--complement-iterator=backward', '--cache=config', '--cache-fail', '--no-cache-evict-after-fail'),
+        ('--split=balanced', '--subset-iterator=skip', '--complement-iterator=forward', '--cache=content', '--cache-fail', '--no-cache-evict-after-fail'),
+        ('--split=zeller', '--subset-iterator=skip', '--complement-iterator=backward', '--cache=content-hash', '--cache-fail', '--no-cache-evict-after-fail'),
     ])
     def test_dd(self, test, inp, exp, tmpdir, args_atom, args):
         self._run_picire(test, inp, exp, tmpdir, args_atom + args)
@@ -61,19 +62,19 @@ class TestCli:
     @pytest.mark.parametrize('args', [
         ('--split=zeller', '--complement-first', '--subset-iterator=forward', '--complement-iterator=forward', '--cache=config'),
         ('--split=balanced', '--complement-first', '--subset-iterator=forward', '--complement-iterator=backward', '--cache=content'),
-        ('--split=zeller', '--subset-iterator=backward', '--complement-iterator=forward', '--cache=none'),
-        ('--split=balanced', '--subset-iterator=backward', '--complement-iterator=backward', '--cache=config'),
-        ('--split=zeller', '--subset-iterator=skip', '--complement-iterator=forward', '--cache=content'),
-        ('--split=balanced', '--subset-iterator=skip', '--complement-iterator=backward', '--cache=none'),
+        ('--split=zeller', '--subset-iterator=backward', '--complement-iterator=forward', '--cache=content-hash'),
+        ('--split=balanced', '--subset-iterator=backward', '--complement-iterator=backward', '--cache=config', '--cache-fail', '--no-cache-evict-after-fail'),
+        ('--split=zeller', '--subset-iterator=skip', '--complement-iterator=forward', '--cache=content', '--cache-fail', '--no-cache-evict-after-fail'),
+        ('--split=balanced', '--subset-iterator=skip', '--complement-iterator=backward', '--cache=content-hash', '--cache-fail', '--no-cache-evict-after-fail'),
     ])
     def test_parallel(self, test, inp, exp, tmpdir, args_atom, args):
         self._run_picire(test, inp, exp, tmpdir, args_atom + ('--parallel', ) + args)
 
     @pytest.mark.parametrize('args', [
-        ('--split=zeller', '--subset-iterator=forward', '--complement-iterator=forward', '--cache=content'),
-        ('--split=balanced', '--subset-iterator=forward', '--complement-iterator=backward', '--cache=none'),
-        ('--split=zeller', '--complement-first', '--subset-iterator=backward', '--complement-iterator=forward', '--cache=config'),
-        ('--split=balanced', '--complement-first', '--subset-iterator=backward', '--complement-iterator=backward', '--cache=content'),
+        ('--split=zeller', '--subset-iterator=forward', '--complement-iterator=forward', '--cache=none'),
+        ('--split=balanced', '--subset-iterator=forward', '--complement-iterator=backward', '--cache=config'),
+        ('--split=zeller', '--complement-first', '--subset-iterator=backward', '--complement-iterator=forward', '--cache=content'),
+        ('--split=balanced', '--complement-first', '--subset-iterator=backward', '--complement-iterator=backward', '--cache=content-hash'),
     ])
     def test_combined(self, test, inp, exp, tmpdir, args_atom, args):
         self._run_picire(test, inp, exp, tmpdir, args_atom + ('--parallel', '--combine-loops', ) + args)


### PR DESCRIPTION
The following optimizations aim at enhancing the memory usage of the cache. They may also have a positive effect on the running time of the cache access operations because of the reduced size of the cache.

- Adding failing configurations, i.e., interesting test cases to the cache is superfluous, since once a fail is found, all subsequent configurations during the reduction will be smaller. So, this new cache entry would not generate a hit afterwards.
- When a failing configuration is found, then all cache entries that belong to larger configurations should be evicted, since all subsequent configurations during the reduction will be smaller. So, these old cache entries would not generate hits afterwards.
- When using content caching, storing a hashed version of the content instead of the content itself should be sufficient. Cache collisions are expected to be rare and even if they happen, they do not violate the correctness of the algorithm, they may only cause suboptimal, i.e., non-minimal results (assuming that failing configurations are not added to the cache).