### PR TITLE
Pylint-induced maintenance

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -13,7 +13,6 @@ disable=
     broad-except,
     duplicate-code,
     fixme,
-    import-outside-toplevel,
     invalid-name,
     line-too-long,
     missing-docstring,
@@ -23,7 +22,6 @@ disable=
     too-many-arguments,
     too-many-branches,
     unused-argument,
-    useless-object-inheritance,
     useless-option-value,  # disables warning in recent pylint that does not check for no-self-use anymore
 
 [REPORTS]

--- a/picire/cache.py
+++ b/picire/cache.py
@@ -11,7 +11,7 @@ from hashlib import sha3_256
 from .outcome import Outcome
 
 
-class CacheRegistry(object):
+class CacheRegistry:
     registry = {}
 
     @classmethod
@@ -22,7 +22,7 @@ class CacheRegistry(object):
         return decorator
 
 
-class OutcomeCache(object):
+class OutcomeCache:
     """
     Abstract base class for configuration outcome caching strategies.
     """
@@ -101,7 +101,7 @@ class ConfigCache(OutcomeCache):
     outcomes, using a tree as the underlying data structure.
     """
 
-    class _Entry(object):
+    class _Entry:
         """
         This class holds test outcomes for configurations. This avoids running
         the same test twice.

--- a/picire/dd.py
+++ b/picire/dd.py
@@ -17,7 +17,7 @@ from .splitter import ZellerSplit
 logger = logging.getLogger(__name__)
 
 
-class DD(object):
+class DD:
     """
     Single process version of the Delta Debugging algorithm.
     """

--- a/picire/iterator.py
+++ b/picire/iterator.py
@@ -5,7 +5,10 @@
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-class IteratorRegistry(object):
+from random import shuffle
+
+
+class IteratorRegistry:
     registry = {}
 
     @classmethod
@@ -51,14 +54,12 @@ def random(n):
     :param n: Upper bound of the interval.
     :return: Numbers in random order from 0 to n - 1.
     """
-    from random import shuffle
-
     lst = list(range(n))
     shuffle(lst)
     yield from lst
 
 
-class CombinedIterator(object):
+class CombinedIterator:
     """
     Callable iterator class that acts as generator when subset and complement
     check loops are combined.

--- a/picire/parallel_loop.py
+++ b/picire/parallel_loop.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -52,7 +52,7 @@ def loop_body(shared_break, shared_slots, shared_lock, i, target, args):
         shared_lock.notify()
 
 
-class Loop(object):
+class Loop:
     """
     Parallel loop implementation based on multiprocessing module.
     """

--- a/picire/shared_cache.py
+++ b/picire/shared_cache.py
@@ -21,7 +21,7 @@ class SharedCacheManager(BaseManager):
     _managers = {}
 
 
-class SharedCacheConstructor(object):
+class SharedCacheConstructor:
     """
     Wrapper for cache classes to instantiate them as shared.
     """

--- a/picire/splitter.py
+++ b/picire/splitter.py
@@ -5,7 +5,7 @@
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-class SplitterRegistry(object):
+class SplitterRegistry:
     registry = {}
 
     @classmethod
@@ -17,7 +17,7 @@ class SplitterRegistry(object):
 
 
 @SplitterRegistry.register('zeller')
-class ZellerSplit(object):
+class ZellerSplit:
     """
     Splits up the input config into n pieces as used by Zeller in the original
     reference implementation. The approach works iteratively in n steps, first
@@ -57,7 +57,7 @@ class ZellerSplit(object):
 
 
 @SplitterRegistry.register('balanced')
-class BalancedSplit(object):
+class BalancedSplit:
     """
     Slightly different version of Zeller's split. This version keeps the split
     balanced by distributing the residuals of the integer division among all

--- a/picire/subprocess_test.py
+++ b/picire/subprocess_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -14,7 +14,7 @@ from subprocess import run
 from .outcome import Outcome
 
 
-class SubprocessTest(object):
+class SubprocessTest:
 
     def __init__(self, *, test_builder, command_pattern, work_dir, filename, encoding='utf-8', cleanup=True):
         """
@@ -74,7 +74,7 @@ class SubprocessTest(object):
         return Outcome.FAIL if returncode == 0 else Outcome.PASS
 
 
-class ConcatTestBuilder(object):
+class ConcatTestBuilder:
     """
     Callable class that builds test case from a configuration.
     """


### PR DESCRIPTION
- Remove the explicit `object` superclass definition from classes. In Python3, object is the implicit superclass. There is no need to explicitly define it.
- Since iterators are not collected by checking the global names in the `iterator` module, imports can be toplevel.