### PR TITLE
Ensure test quality via linting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -20,6 +20,7 @@ disable=
     protected-access,
     too-few-public-methods,
     too-many-arguments,
+    too-many-boolean-expressions,
     too-many-branches,
     unused-argument,
     useless-option-value,  # disables warning in recent pylint that does not check for no-self-use anymore

--- a/tests/resources/exp-sumprod10-prod.py
+++ b/tests/resources/exp-sumprod10-prod.py
@@ -1,4 +1,4 @@
-prod = 1
-for i in range(1,11):
-    prod *= i
-print(f'prod: {prod}')
+p = 1
+for i in range(1, 11):
+    p *= i
+print(f'prod: {p}')

--- a/tests/resources/exp-sumprod10-sum.py
+++ b/tests/resources/exp-sumprod10-sum.py
@@ -1,4 +1,4 @@
-sum = 0
-for i in range(1,11):
-    sum += i
-print(f'sum: {sum}')
+s = 0
+for i in range(1, 11):
+    s += i
+print(f'sum: {s}')

--- a/tests/resources/inp-sumprod10.py
+++ b/tests/resources/inp-sumprod10.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
-sum = 0
-prod = 1
-for i in range(1,11):
-    sum += i
-    prod *= i
+s = 0
+p = 1
+for i in range(1, 11):
+    s += i
+    p *= i
 
-print(f'sum: {sum}')
-print(f'prod: {prod}')
+print(f'sum: {s}')
+print(f'prod: {p}')

--- a/tests/resources/sut-json-load.py
+++ b/tests/resources/sut-json-load.py
@@ -4,7 +4,7 @@ import json
 import sys
 
 
-with open(sys.argv[1], 'r') as f:
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
     j = json.load(f)
 
-print(f'j!r')
+print(f'{j!r}')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,6 +20,7 @@ def interesting_a(c):
         return True
     return False
 
+
 config_a = [1, 2, 3, 4, 5, 6, 7, 8]
 expect_a = [5, 8]
 
@@ -27,20 +28,20 @@ expect_a = [5, 8]
 def interesting_b(c):
     if not c:
         return False
-    if 1 in c and 2 in c and 3 in c and 4 in c and \
-                    5 in c and 6 in c and 7 in c and 8 in c:
+    if all(d in c for d in [1, 2, 3, 4, 5, 6, 7, 8]):
         return True
     return False
+
 
 config_b = [1, 2, 3, 4, 5, 6, 7, 8]
 expect_b = [1, 2, 3, 4, 5, 6, 7, 8]
 
 
 def interesting_c(c):
-    if 1 in c and 2 in c and 3 in c and 4 in c and \
-       6 in c and 8 in c:
+    if all(d in c for d in [1, 2, 3, 4, 6, 8]):
         return True
     return False
+
 
 config_c = [1, 2, 3, 4, 5, 6, 7, 8]
 expect_c = [1, 2, 3, 4, 6, 8]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,9 +8,10 @@
 
 import os
 import platform
-import pytest
 import subprocess
 import sys
+
+import pytest
 
 
 is_windows = sys.platform.startswith('win32')
@@ -37,9 +38,9 @@ class TestCli:
     def _run_picire(self, test, inp, exp, tmpdir, args):
         out_dir = str(tmpdir)
         cmd = (sys.executable, '-m', 'picire') \
-              + (f'--test={test}{script_ext}', f'--input={inp}', f'--out={out_dir}') \
-              + ('--log-level=TRACE', ) \
-              + args
+            + (f'--test={test}{script_ext}', f'--input={inp}', f'--out={out_dir}') \
+            + ('--log-level=TRACE', ) \
+            + args
         subprocess.run(cmd, cwd=resources_dir, check=True)
 
         with open(os.path.join(out_dir, inp), 'rb') as outf:

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,10 @@ usedevelop = true
 deps =
     pycodestyle
     pylint
+    pytest
 commands =
-    pylint picire
-    pycodestyle picire --ignore=E501
+    pylint picire tests
+    pycodestyle picire tests --ignore=E501
 
 [testenv:build]
 deps =


### PR DESCRIPTION
- Fix long-standing issue of missing braces in an f-string
- Avoid shadowing builtins (sum)
- Specify encoding when opening a file
- List standard modules first in imports.
- Avoid visual indenting (triggered not only reformatting but also some rewriting)
- Use whitespace after commas, two blank lines after top-level elements